### PR TITLE
Fixed string constant in code examples

### DIFF
--- a/xap100adm/tuning-handling-large-objects.markdown
+++ b/xap100adm/tuning-handling-large-objects.markdown
@@ -72,9 +72,7 @@ public static void main(String[] args) {
 
 	//reading Space File from space
 	SpaceFile spaceFile2 = gigaspace.readById(SpaceFile.class, "test.pdf");
-	bytesTofile(spaceFile2.getContent(), "d:
-  temp
-  test_.pdf");
+	bytesTofile(spaceFile2.getContent(), "d:/temp/test_.pdf");
 }
 
 public static byte[] fileToBytes(String fileName) {


### PR DESCRIPTION
Looks like \ we replaced by some formatting. Using / is possible in windows envs as well so it would still be portable.