### PR TITLE
Fix for broken links in documentation

### DIFF
--- a/xap100/your-first-real-time-big-data-analytics-application.markdown
+++ b/xap100/your-first-real-time-big-data-analytics-application.markdown
@@ -193,7 +193,7 @@ Once the build is complete, a summary message similar to the following is displa
 Since the application is a Maven project, you can load it using your Java IDE and thus automatically configure all module and classpath configurations.
 
 - With [IntelliJ](http://www.intellij.com), simply click "File -> Open Project" and point to `<applicationRoot>/pom.xml`. IntelliJ will load the project and present the modules for you.
-- With [Eclipse](http://www.eclipse.org), install the [`M2Eclipse plugin`](http://eclipse.org/m2e/download/) and click "File -> Import" , "Maven -> Existing Maven Projects" , select the `streaming-bigdata` folder and click the `Finish` button.
+- With [Eclipse](http://www.eclipse.org), install the [`M2Eclipse plugin`](http://eclipse.org/m2e/m2e-downloads.html) and click "File -> Import" , "Maven -> Existing Maven Projects" , select the `streaming-bigdata` folder and click the `Finish` button.
 
 
 {%section%}


### PR DESCRIPTION
Links to "The Bootstrapping Process" and "M2Eclipse plugin" appear to be broken. I've patched plugin link but cannot find a working link for "The Bootstrapping Process".

_Broken links were found automatically by my new application, I have not published it yet. If you have any need to search for broken links in another documentation storage, feel free to contact me._