### PR TITLE
Fix for broken links in documentation

### DIFF
--- a/xap100/memcached-api.markdown
+++ b/xap100/memcached-api.markdown
@@ -37,7 +37,7 @@ The last deployment model uses a single access point for access - a single node 
 
 # Using memcached
 
-Memcached uses a standardized and language-neutral [protocol](http://www.sixapart.com/labs/memcached/), providing fourteen commands (six reads, two sets, two updates, one delete, and some status-related commands), issued over a plain text connection. A client application can open a telnet session and use a memcached server with no problems (assuming no errors are made in using the protocol, of course.)
+Memcached uses a standardized and language-neutral [protocol](https://code.google.com/p/memcached/wiki/NewCommands), providing fourteen commands (six reads, two sets, two updates, one delete, and some status-related commands), issued over a plain text connection. A client application can open a telnet session and use a memcached server with no problems (assuming no errors are made in using the protocol, of course.)
 
 However, since the protocol is simple and well-known, there have been many client libraries written that provide access to memcached services.
 


### PR DESCRIPTION
A link to memcached protocol commands appeared to be broken, I've replaces it with the link to their new wiki on Google Code.

_Broken links were found automatically by my new application, I have not published it yet. If you have any need to search for broken links in another documentation storage, feel free to contact me._