### PR TITLE
missing </class> In SpaceFifoGroupingIndex ex

### DIFF
--- a/xap100/pojo-xml-metadata-attribute.markdown
+++ b/xap100/pojo-xml-metadata-attribute.markdown
@@ -185,13 +185,14 @@ Example:
 
 {%highlight java%}
 <gigaspaces-mapping>
-	<class name="com.gigaspaces.examples.FlightReservation />
+	<class name="com.gigaspaces.examples.FlightReservation" >
 		<property name="processingState">
 			<fifo-grouping-index />
 		</property>
 		<property name="customer">
 			<fifo-grouping-index  path="id"/>
 		</property>
+	</class>
 </gigaspaces-mapping>
 
 {%endhighlight%}


### PR DESCRIPTION
In SpaceFifoGroupingIndex example is missing a trailling </class> tag and a extra "/" at the end of the opening class tag.

Regards.