### PR TITLE
Fixing typo in Sysdate what’s new and adding foot

### DIFF
--- a/xap101/query-sql.markdown
+++ b/xap101/query-sql.markdown
@@ -246,9 +246,8 @@ The `sysdate` value is evaluated differently when using the JDBC API vs when usi
 
 - On windows there is a [windows service](http://technet.microsoft.com/en-us/library/cc773061%28WS.10%29.aspx) that deals with clock synchronization.
 - On Linux there is a [daemon service](http://www.brennan.id.au/09-Network_Time_Protocol.html#starting) that deals with clock synchronization.
-
 {% tip %}
-GigaSpaces using internally the **TimeStamp** data type to store dates. This means the date includes beyond the year, month and day, the hour/min/sec portions. If you are looking to query for a specific date you should perform a date range query.
+Internally dates are stored as a **TimeStamp**. This means that both time (hour/min/sec) and date (year/month/day) information are available for date range queries.
 {% endtip %}
 
 
@@ -442,6 +441,10 @@ public void testLocalDateTime() {
 {%endaccord%}
 
 {%endaccordion%}
+
+{%warning%}
+Java 8's LocalDate, LocalTime, LocalDateTime are currently not interoperable with the .NET DateTime class. [.NET Interoperability](/xap101net/dotnet-java-interoperability.html#supported-types-for-matching-and-interoperability)
+{%endwarning%}
 
 # Aggregators
 

--- a/xap101net/dotnet-java-interoperability.markdown
+++ b/xap101net/dotnet-java-interoperability.markdown
@@ -137,6 +137,10 @@ The following types are supported by the space for matching and interoperability
 3. In .Net a `DateTime` is measured in ticks (=100 nanoseconds) since 1/1/0001, whereas in java a `Date` is a measured in milliseconds since 1/1/1970.
 4. The types `Decimal` (.Net) and `BigDecimal` (java) have different precision and range (see .Net and java documentation for more details). In addition, be aware that serialization/de serialization of these types is relatively slow, compared to other numeric types. As a rule of thumb these types should not be used, unless the other numeric types precision/range is not satisfactory.
 
+{%warning%}
+Java 8's LocalDate, LocalTime, LocalDateTime are currently not interoperable with the .NET DateTime class.
+{%endwarning%}
+
 # Arrays and Collections support
 
 The following collections are mapped for interoperability:

--- a/xap102net/dotnet-java-interoperability.markdown
+++ b/xap102net/dotnet-java-interoperability.markdown
@@ -137,6 +137,10 @@ The following types are supported by the space for matching and interoperability
 3. In .Net a `DateTime` is measured in ticks (=100 nanoseconds) since 1/1/0001, whereas in java a `Date` is a measured in milliseconds since 1/1/1970.
 4. The types `Decimal` (.Net) and `BigDecimal` (java) have different precision and range (see .Net and java documentation for more details). In addition, be aware that serialization/de serialization of these types is relatively slow, compared to other numeric types. As a rule of thumb these types should not be used, unless the other numeric types precision/range is not satisfactory.
 
+{%warning%}
+Java 8's LocalDate, LocalTime, LocalDateTime are currently not interoperable with the .NET DateTime class.
+{%endwarning%}
+
 # Arrays and Collections support
 
 The following collections are mapped for interoperability:


### PR DESCRIPTION
notes for Java 8’s new DateTime API interoperability.