### PR TITLE
Update the-runtime-environment.markdown

### DIFF
--- a/xap102adm/the-runtime-environment.markdown
+++ b/xap102adm/the-runtime-environment.markdown
@@ -146,7 +146,7 @@ For example, suppose we want our agent to load 2 'small' GSCs (512MB each) in a 
             windows="${com.gs.home}/bin/gs.bat" unix="${com.gs.home}/bin/gs.sh">
         <argument>start</argument>
         <argument>"GSC"</argument>
-		<environment name="GSC_JAVA_OPTIONS">-Xmx512m -Dcom.gs.zones=Small</environment>
+		<environment name="GSC_JAVA_OPTIONS">-Xms512m -Xmx512m -Dcom.gs.zones=Small</environment>
     </script>
     <vm enable="true" work-dir="${com.gs.home}/bin" main-class="com.gigaspaces.start.SystemBoot">
         <input-argument></input-argument>
@@ -163,7 +163,7 @@ For example, suppose we want our agent to load 2 'small' GSCs (512MB each) in a 
             windows="${com.gs.home}/bin/gs.bat" unix="${com.gs.home}/bin/gs.sh">
         <argument>start</argument>
         <argument>"GSC"</argument>
-		<environment name="GSC_JAVA_OPTIONS">-Xmx1024m -Dcom.gs.zones=Large</environment>
+		<environment name="GSC_JAVA_OPTIONS">-Xms1024m -Xmx1024m -Dcom.gs.zones=Large</environment>
     </script>
     <vm enable="true" work-dir="${com.gs.home}/bin" main-class="com.gigaspaces.start.SystemBoot">
         <input-argument></input-argument>


### PR DESCRIPTION
Our recommendation is always to set Xms and Xmx with the same value.
The current description misleads the customers.